### PR TITLE
Fix build, make statusbar and palette optional, update readme

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,9 +12,16 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
-    '@typescript-eslint/interface-name-prefix': [
-      'error',
-      { prefixWithI: 'always' }
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "interface",
+        "format": ["PascalCase"],
+        "custom": {
+          "regex": "^I[A-Z]",
+          "match": true
+        }
+      }
     ],
     '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
     '@typescript-eslint/no-explicit-any': 'off',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,5 @@ jobs:
         jlpm run eslint:check
         python -m pip install .
 
-        jupyter labextension list 2>&1 | grep -ie "@jupyterlab-contrib/jupyterlab_spellchecker.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@ijmbarr/jupyterlab_spellchecker.*OK"
         python -m jupyterlab.browser_check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,5 @@ jobs:
         jlpm run eslint:check
         python -m pip install .
 
-        jupyter labextension list 2>&1 | grep -ie "@ijmbarr/jupyterlab_spellchecker.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jupyterlab-contrib/jupyterlab_spellchecker.*OK"
         python -m jupyterlab.browser_check

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 **/node_modules
 **/lib
 **/package.json
+jupyterlab_spellchecker

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,13 @@
 include LICENSE
 include README.md
 include pyproject.toml
-include jupyter-config/jupyterlab_spellchecke.json
 
 include package.json
 include install.json
 include ts*.json
 include yarn.lock
 
-graft jupyterlab_spellchecker/labextension
+graft jupyterlab-spellchecker/labextension
 
 # Javascript files
 graft src

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include install.json
 include ts*.json
 include yarn.lock
 
-graft jupyterlab-spellchecker/labextension
+graft jupyterlab_spellchecker/labextension
 
 # Javascript files
 graft src

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,26 @@
+include LICENSE
+include README.md
+include pyproject.toml
+include jupyter-config/jupyterlab_spellchecke.json
+
+include package.json
+include install.json
+include ts*.json
+include yarn.lock
+
+graft jupyterlab_spellchecker/labextension
+
+# Javascript files
+graft src
+graft style
+graft dictionaries
+prune **/node_modules
+prune lib
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The JupyterLab extension is based on [the spellchecker Jupyter Notebook extensio
 The extension provides (Hunspell) [SCOWL](http://wordlist.aspell.net/) dictionaries for:
 - American, British, Canadian, and Australian English
 - French,
+- German (Germany, Austria, Switzerland)
 - Portuguese,
 - Spanish.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jupyterlab_spellchecker
+# jupyterlab-spellchecker
 ![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab_spellchecker/workflows/Build/badge.svg)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab_spellchecker/master?urlpath=lab)
 
@@ -19,11 +19,21 @@ The extension has been tested up to JupyterLab version 3.0.
 
 ## Installation
 
+For JupyterLab 3.x:
+
+```bash
+pip install jupyterlab-spellchecker
+```
+
+For JupyterLab 2.x:
+
 ```bash
 jupyter labextension install @ijmbarr/jupyterlab_spellchecker
 ```
 
-## Development
+## Contributing
+
+### Development install
 
 Note: You will need NodeJS to build the extension package.
 
@@ -32,7 +42,10 @@ The `jlpm` command is JupyterLab's pinned version of
 `yarn` or `npm` in lieu of `jlpm` below.
 
 ```bash
-jlpm
+# Clone the repo to your local environment
+# Change directory to the jupyterlab_spellchecker directory
+# Install package in development mode
+pip install -e .
 # Link your development version of the extension with JupyterLab
 jupyter labextension develop . --overwrite
 # Rebuild extension Typescript source after making changes
@@ -46,4 +59,18 @@ You can watch the source directory and run JupyterLab at the same time in differ
 jlpm run watch
 # Run JupyterLab in another terminal
 jupyter lab
+```
+
+### Before commit
+
+Make sure that eslint passes:
+
+```bash
+jlpm run eslint:check
+```
+
+If there are any issues it might be possible to autofix them with:
+
+```bash
+jlpm run eslint
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # jupyterlab_spellchecker
+![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab_spellchecker/workflows/Build/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab_spellchecker/master?urlpath=lab)
 
 A JupyterLab extension highlighting misspelled words in markdown cells within notebooks and in the text files.
 
@@ -6,10 +8,14 @@ A JupyterLab extension highlighting misspelled words in markdown cells within no
 
 The JupyterLab extension is based on [the spellchecker Jupyter Notebook extension](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/spellchecker) and relies on [Typo.js](https://github.com/cfinke/Typo.js) for the actual spell checking. Spellchecker suggestions are available from the context menu.
 
-The extension provides (Hunspell) [SCOWL](http://wordlist.aspell.net/) dictionaries for American, British, Canadian, and Australian English.
+The extension provides (Hunspell) [SCOWL](http://wordlist.aspell.net/) dictionaries for:
+- American, British, Canadian, and Australian English
+- French,
+- Portuguese,
+- Spanish.
 
 ## JupyterLab Version
-The extension has been tested up to JupyterLab version 2.2.0.
+The extension has been tested up to JupyterLab version 3.0.
 
 ## Installation
 
@@ -19,17 +25,25 @@ jupyter labextension install @ijmbarr/jupyterlab_spellchecker
 
 ## Development
 
-For a development installation (requires npm version 4 or later), do the following in the repository directory:
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
 
 ```bash
-npm install
-npm run build
-jupyter labextension link .
+jlpm
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm run build
 ```
 
-To rebuild the package and the JupyterLab app:
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
 
 ```bash
-npm run build
-jupyter lab build
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm run watch
+# Run JupyterLab in another terminal
+jupyter lab
 ```

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,19 @@
+# a mybinder.org-ready environment for demoing jupyterlab-spellchecker
+# this environment may also be used locally on Linux/MacOS/Windows, e.g.
+#
+#   conda env update --file binder/environment.yml
+#   conda activate jupyterlab-spellchecker-demo
+#
+name: jupyterlab-spellchecker-demo
+
+channels:
+  - conda-forge
+
+dependencies:
+  # runtime dependencies
+  - python >=3.8,<3.9.0a0
+  - jupyterlab >=3,<4.0.0a0
+  # labextension build dependencies
+  - nodejs >=14,<15
+  - pip
+  - wheel

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+""" perform a development install of jupyterlab-spellchecker
+
+    On Binder, this will run _after_ the environment has been fully created from
+    the environment.yml in this directory.
+
+    This script should also run locally on Linux/MacOS/Windows:
+
+        python3 binder/postBuild
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+
+def _(*args, **kwargs):
+    """ Run a command, echoing the args
+
+        fails hard if something goes wrong
+    """
+    print("\n\t", " ".join(args), "\n")
+    return_code = subprocess.call(args, **kwargs)
+    if return_code != 0:
+        print("\nERROR", return_code, " ".join(args))
+        sys.exit(return_code)
+
+# verify the environment is self-consistent before even starting
+_(sys.executable, "-m", "pip", "check")
+
+# install the labextension
+_(sys.executable, "-m", "pip", "install", "-e", ".")
+
+# verify the environment the extension didn't break anything
+_(sys.executable, "-m", "pip", "check")
+
+# list the extensions
+_("jupyter", "server", "extension", "list")
+
+# initially list installed extensions to determine if there are any surprises
+_("jupyter", "labextension", "list")
+
+
+print("JupyterLab with jupyterlab-spellchecker is ready to run with:\n")
+print("\tjupyter lab\n")

--- a/install.json
+++ b/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "jupyterlab-spellchecker",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab-spellchecker"
+}

--- a/jupyterlab_spellchecker/__init__.py
+++ b/jupyterlab_spellchecker/__init__.py
@@ -1,0 +1,16 @@
+
+import json
+from pathlib import Path
+
+from ._version import __version__
+
+HERE = Path(__file__).parent.resolve()
+
+with (HERE / "labextension" / "package.json").open() as fid:
+    data = json.load(fid)
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": data["name"]
+    }]

--- a/jupyterlab_spellchecker/_version.py
+++ b/jupyterlab_spellchecker/_version.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+__all__ = ["__version__"]
+
+def _fetchVersion():
+    HERE = Path(__file__).parent.resolve()
+
+    for settings in HERE.rglob("package.json"): 
+        try:
+            with settings.open() as f:
+                return json.load(f)["version"]
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
+__version__ = _fetchVersion()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyterlab-contrib/jupyterlab_spellchecker",
   "version": "0.3.0",
-  "description": "A spell checker for jupyterlab.",
+  "description": "A spell checker for JupyterLab.",
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -9,7 +9,7 @@
   ],
   "homepage": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker",
   "bugs": {
-    "url": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker/issues"
   },
   "license": "BSD-3-Clause",
   "contributors": [
@@ -31,11 +31,22 @@
     "url": "git+https://github.com/jupyterlab-contrib/jupyterlab_spellchecker.git"
   },
   "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w",
+    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
+    "build:prod": "jlpm run build:lib && jlpm run build:labextension",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:lib": "tsc",
+    "clean": "jlpm run clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:labextension": "rimraf {{ cookiecutter.python_name }}/labextension",
+    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
     "eslint": "eslint . --ext .ts,.tsx --fix",
-    "eslint:check": "eslint . --ext .ts,.tsx"
+    "eslint:check": "eslint . --ext .ts,.tsx",
+    "install:extension": "jupyter labextension develop --overwrite .",
+    "prepare": "jlpm run clean && jlpm run build:prod",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:src": "tsc -w",
+    "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
     "@jupyterlab/application": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ijmbarr/jupyterlab_spellchecker",
+  "name": "@jupyterlab-contrib/jupyterlab_spellchecker",
   "version": "0.3.0",
   "description": "A spell checker for jupyterlab.",
   "keywords": [
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/ijmbarr/jupyterlab_spellchecker",
+  "homepage": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker",
   "bugs": {
-    "url": "https://github.com/ijmbarr/jupyterlab_spellchecker"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker"
   },
   "license": "BSD-3-Clause",
   "contributors": [
@@ -28,12 +28,14 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ijmbarr/jupyterlab_spellchecker.git"
+    "url": "git+https://github.com/jupyterlab-contrib/jupyterlab_spellchecker.git"
   },
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "eslint": "eslint . --ext .ts,.tsx --fix",
+    "eslint:check": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
     "@jupyterlab/application": "^3.0.3",
@@ -63,7 +65,7 @@
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema",
-    "outputDir": "ijmbarr_jupyterlab_spellchecker/labextension"
+    "outputDir": "jupyterlab_spellchecker/labextension"
   },
   "styleModule": "style/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
     "typo-js": "^1.1.0"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^3.0.0-rc.13",
-    "@typescript-eslint/eslint-plugin": "^2.27.0",
-    "@typescript-eslint/parser": "^2.27.0",
-    "eslint": "^7.5.0",
-    "eslint-config-prettier": "^6.10.1",
-    "eslint-plugin-prettier": "^3.1.2",
+    "@jupyterlab/builder": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
+    "eslint": "^7.14.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.0",
+    "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
     "typescript": "~4.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyterlab-contrib/jupyterlab_spellchecker",
+  "name": "@ijmbarr/jupyterlab_spellchecker",
   "version": "0.4.0",
   "description": "A spell checker for JupyterLab.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/jupyterlab-contrib/jupyterlab_spellchecker/issues"
   },
   "license": "BSD-3-Clause",
+  "author": {
+    "name": "JupyterLab Spellchecker Development Team",
+  },
   "contributors": [
     "Iain Barr",
     "Micha\u0142 Krassowski",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "BSD-3-Clause",
   "author": {
-    "name": "JupyterLab Spellchecker Development Team",
+    "name": "JupyterLab Spellchecker Development Team"
   },
   "contributors": [
     "Iain Barr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab-contrib/jupyterlab_spellchecker",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A spell checker for JupyterLab.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema",
-    "outputDir": "jupyterlab_spellchecker/labextension"
+    "outputDir": "jupyterlab-spellchecker/labextension"
   },
   "styleModule": "style/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:lib": "tsc",
     "clean": "jlpm run clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:labextension": "rimraf {{ cookiecutter.python_name }}/labextension",
+    "clean:labextension": "rimraf jupyterlab_spellchecker/labextension",
     "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",
@@ -79,7 +79,7 @@
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema",
-    "outputDir": "jupyterlab-spellchecker/labextension"
+    "outputDir": "jupyterlab_spellchecker/labextension"
   },
   "styleModule": "style/index.js"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup_args = dict(
     version=pkg_json["version"],
     url=pkg_json["homepage"],
     author=pkg_json["author"]["name"],
-    author_email=pkg_json["author"]["email"],
     description=pkg_json["description"],
     license=pkg_json["license"],
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+
+from jupyter_packaging import (
+    create_cmdclass,
+    install_npm,
+    ensure_targets,
+    combine_commands,
+    skip_if_exists
+)
+import setuptools
+
+HERE = Path(__file__).parent.resolve()
+
+# The name of the project
+name = "jupyterlab-spellchecker"
+
+lab_path = (HERE / name / "labextension")
+
+# Representative files that should exist after a successful build
+jstargets = [
+    str(lab_path / "package.json"),
+]
+
+package_data_spec = {
+    name: ["*"],
+}
+
+labext_name = "{{ cookiecutter.labextension_name }}"
+
+data_files_spec = [
+    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
+    ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
+]
+
+cmdclass = create_cmdclass("jsdeps",
+    package_data_spec=package_data_spec,
+    data_files_spec=data_files_spec
+)
+
+js_command = combine_commands(
+    install_npm(HERE, build_cmd="build:prod", npm=["jlpm"]),
+    ensure_targets(jstargets),
+)
+
+is_repo = (HERE / ".git").exists()
+if is_repo:
+    cmdclass["jsdeps"] = js_command
+else:
+    cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+
+long_description = (HERE / "README.md").read_text()
+
+# Get the package info from package.json
+pkg_json = json.loads((HERE / "package.json").read_bytes())
+
+setup_args = dict(
+    name=name,
+    version=pkg_json["version"],
+    url=pkg_json["homepage"],
+    author=pkg_json["author"]["name"],
+    author_email=pkg_json["author"]["email"],
+    description=pkg_json["description"],
+    license=pkg_json["license"],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    cmdclass=cmdclass,
+    packages=setuptools.find_packages(),
+    install_requires=[
+        "jupyterlab~=3.0",
+    ],
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.6",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Framework :: Jupyter",
+    ],
+)
+
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ HERE = Path(__file__).parent.resolve()
 # The name of the project
 name = "jupyterlab-spellchecker"
 
-lab_path = (HERE / name / "labextension")
+lab_path = (HERE / name.replace('-', '_') / "labextension")
 
 # Representative files that should exist after a successful build
 jstargets = [
@@ -26,7 +26,7 @@ package_data_spec = {
     name: ["*"],
 }
 
-labext_name = "{{ cookiecutter.labextension_name }}"
+labext_name = "@jupyterlab-contrib/jupyterlab_spellchecker"
 
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ package_data_spec = {
     name: ["*"],
 }
 
-labext_name = "@jupyterlab-contrib/jupyterlab_spellchecker"
+labext_name = "@ijmbarr/jupyterlab_spellchecker"
 
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -578,9 +578,9 @@ class SpellChecker {
 function activate(
   app: JupyterFrontEnd,
   tracker: INotebookTracker,
-  palette: ICommandPalette,
   editor_tracker: IEditorTracker,
   setting_registry: ISettingRegistry,
+  palette: ICommandPalette,
   status_bar: IStatusBar
 ): void {
   console.log('Attempting to load spellchecker');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,20 @@
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin,
+} from '@jupyterlab/application';
 import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { LabIcon } from '@jupyterlab/ui-components';
-import { ICommandPalette, InputDialog, ReactWidget } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  InputDialog,
+  ReactWidget,
+} from '@jupyterlab/apputils';
 import { Menu } from '@lumino/widgets';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { IStatusBar, TextItem } from "@jupyterlab/statusbar";
-import { Cell } from "@jupyterlab/cells";
+import { IStatusBar, TextItem } from '@jupyterlab/statusbar';
+import { Cell } from '@jupyterlab/cells';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import * as CodeMirror from 'codemirror';
 
@@ -14,38 +22,44 @@ import '../style/index.css';
 import spellcheckSvg from '../style/icons/ic-baseline-spellcheck.svg';
 
 export const spellcheckIcon = new LabIcon({
-    name: 'spellcheck:spellcheck',
-    svgstr: spellcheckSvg
+  name: 'spellcheck:spellcheck',
+  svgstr: spellcheckSvg,
 });
 
-declare function require(name:string): any;
-let Typo = require("typo-js");
+declare function require(name: string): any;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Typo = require('typo-js');
 
-const CMD_APPLY_SUGGESTION = 'spellchecker:apply-suggestion';
-const CMD_IGNORE_WORD = 'spellchecker:ignore'
-const CMD_TOGGLE = 'spellchecker:toggle-check-spelling';
-const CMD_UPDATE_SUGGESTIONS = 'spellchecker:update-suggestions';
+const enum CommandIDs {
+  applySuggestion = 'spellchecker:apply-suggestion',
+  ignoreWord = 'spellchecker:ignore',
+  toggle = 'spellchecker:toggle-check-spelling',
+  updateSuggestions = 'spellchecker:update-suggestions',
+  chooseLanguage = 'spellchecker:choose-language',
+}
 
-const TEXT_SUGGESTIONS_AVAILABLE = 'Adjust spelling to'
-const TEXT_NO_SUGGESTIONS = 'No spellcheck suggestions'
+const TEXT_SUGGESTIONS_AVAILABLE = 'Adjust spelling to';
+const TEXT_NO_SUGGESTIONS = 'No spellcheck suggestions';
+
+const PALETTE_CATEGORY = 'Spell Checker';
 
 interface IWord {
-    line: number;
-    start: number;
-    end: number;
-    text: string;
+  line: number;
+  start: number;
+  end: number;
+  text: string;
 }
 
 interface IContext {
-    editor: CodeMirror.Editor;
-    position: CodeMirror.Position;
+  editor: CodeMirror.Editor;
+  position: CodeMirror.Position;
 }
 
 interface ILanguage {
-    code: string;
-    name: string;
-    aff: string;
-    dic: string;
+  code: string;
+  name: string;
+  aff: string;
+  dic: string;
 }
 
 // English dictionaries come from https://github.com/en-wl/wordlist
@@ -82,432 +96,510 @@ import es_es_dic from 'file-loader!../dictionaries/es_ES.dic';
 import pt_pt_aff from 'file-loader!../dictionaries/pt_PT.aff';
 import pt_pt_dic from 'file-loader!../dictionaries/pt_PT.dic';
 
-
 const languages: ILanguage[] = [
-    {code: 'en-us', name: 'English (American)', aff: en_aff, dic: en_dic},
-    {code: 'en-gb', name: 'English (British)', aff: en_gb_aff, dic: en_gb_dic},
-    {code: 'en-ca', name: 'English (Canadian)', aff: en_ca_aff, dic: en_ca_dic},
-    {code: 'en-au', name: 'English (Australian)', aff: en_au_aff, dic: en_au_dic},
-    {code: 'de-de', name: 'Deutsch (Deutschland)', aff: de_de_aff, dic: de_de_dic},
-    {code: 'de-at', name: 'Deutsch (Österreich)', aff: de_at_aff, dic: de_at_dic},
-    {code: 'de-ch', name: 'Deutsch (Schweiz)', aff: de_ch_aff, dic: de_ch_dic},
-    {code: 'fr-fr', name: 'Français (France)', aff: fr_fr_aff, dic: fr_fr_dic},
-    {code: 'es-es', name: 'Español (España)', aff: es_es_aff, dic: es_es_dic},
-    //{code: 'it-it', name: 'Italiano (Italia)', aff: it_it_aff, dic: it_it_dic},
-    {code: 'pt-pt', name: 'Português (Portugal)', aff: pt_pt_aff, dic: pt_pt_dic},
-]
+  { code: 'en-us', name: 'English (American)', aff: en_aff, dic: en_dic },
+  { code: 'en-gb', name: 'English (British)', aff: en_gb_aff, dic: en_gb_dic },
+  { code: 'en-ca', name: 'English (Canadian)', aff: en_ca_aff, dic: en_ca_dic },
+  {
+    code: 'en-au',
+    name: 'English (Australian)',
+    aff: en_au_aff,
+    dic: en_au_dic,
+  },
+  {
+    code: 'de-de',
+    name: 'Deutsch (Deutschland)',
+    aff: de_de_aff,
+    dic: de_de_dic,
+  },
+  {
+    code: 'de-at',
+    name: 'Deutsch (Österreich)',
+    aff: de_at_aff,
+    dic: de_at_dic,
+  },
+  { code: 'de-ch', name: 'Deutsch (Schweiz)', aff: de_ch_aff, dic: de_ch_dic },
+  { code: 'fr-fr', name: 'Français (France)', aff: fr_fr_aff, dic: fr_fr_dic },
+  { code: 'es-es', name: 'Español (España)', aff: es_es_aff, dic: es_es_dic },
+  //{code: 'it-it', name: 'Italiano (Italia)', aff: it_it_aff, dic: it_it_dic},
+  {
+    code: 'pt-pt',
+    name: 'Português (Portugal)',
+    aff: pt_pt_aff,
+    dic: pt_pt_dic,
+  },
+];
 
 class StatusWidget extends ReactWidget {
+  language_source: () => string;
 
-    language_source: () => string;
+  constructor(source: () => string) {
+    super();
+    this.language_source = source;
+  }
 
-    constructor(source: () => string) {
-        super();
-        this.language_source = source
-    }
-
-    protected render() {
-        return TextItem({source: this.language_source()});
-    }
+  protected render() {
+    return TextItem({ source: this.language_source() });
+  }
 }
 
 /**
  * SpellChecker
  */
 class SpellChecker {
-    dictionary: any;
-    suggestions_menu: Menu;
-    status_widget: StatusWidget;
+  dictionary: any;
+  suggestions_menu: Menu;
+  status_widget: StatusWidget;
 
-    // Default Options
-    check_spelling: boolean = true;
-    language: ILanguage;
-    rx_word_char: RegExp     = /[^-\[\]{}():\/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
-    rx_non_word_char: RegExp =  /[-\[\]{}():\/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
-    ignored_tokens: Set<string> = new Set();
-    settings: ISettingRegistry.ISettings;
-    accepted_types: string[]
+  // Default Options
+  check_spelling = true;
+  language: ILanguage;
+  rx_word_char = /[^-[\]{}():/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
+  rx_non_word_char = /[-[\]{}():/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
+  ignored_tokens: Set<string> = new Set();
+  settings: ISettingRegistry.ISettings;
+  accepted_types: string[];
 
-    constructor(
-      public app: JupyterFrontEnd, public tracker: INotebookTracker, public palette: ICommandPalette,
-      public editor_tracker: IEditorTracker, public status_bar: IStatusBar, public setting_registry: ISettingRegistry
-    ){
-        // have at least a default
-        this.language = languages[0]
+  constructor(
+    public app: JupyterFrontEnd,
+    public tracker: INotebookTracker,
+    public editor_tracker: IEditorTracker,
+    public setting_registry: ISettingRegistry,
+    public palette?: ICommandPalette,
+    public status_bar?: IStatusBar
+  ) {
+    // have at least a default
+    this.language = languages[0];
 
-        // read the settings
-        this.setup_settings();
+    // read the settings
+    this.setup_settings();
 
-        // setup the static content of the spellchecker UI
-        this.setup_button();
-        this.setup_suggestions();
-        this.setup_language_picker();
-        this.setup_ignore_action()
+    // setup the static content of the spellchecker UI
+    this.setup_button();
+    this.setup_suggestions();
+    this.setup_language_picker();
+    this.setup_ignore_action();
 
-        this.tracker.activeCellChanged.connect(() => this.setup_cell_editor(this.tracker.activeCell));
-        // setup newly open editors
-        this.editor_tracker.widgetAdded.connect((sender, widget) => this.setup_file_editor(widget.content, true));
-        // refresh already open editors when activated (because the MIME type might have changed)
-        this.editor_tracker.currentChanged.connect((sender, widget) => this.setup_file_editor(widget.content, false));
+    this.tracker.activeCellChanged.connect(() =>
+      this.setup_cell_editor(this.tracker.activeCell)
+    );
+    // setup newly open editors
+    this.editor_tracker.widgetAdded.connect((sender, widget) =>
+      this.setup_file_editor(widget.content, true)
+    );
+    // refresh already open editors when activated (because the MIME type might have changed)
+    this.editor_tracker.currentChanged.connect((sender, widget) =>
+      this.setup_file_editor(widget.content, false)
+    );
+  }
+
+  // move the load_dictionary into the setup routine, because then
+  // we know that the values are set correctly!
+  setup_settings() {
+    Promise.all([this.setting_registry.load(extension.id), this.app.restored])
+      .then(([settings]) => {
+        this.update_settings(settings);
+        settings.changed.connect(() => {
+          this.update_settings(settings);
+        });
+      })
+      .catch((reason: Error) => {
+        console.error(reason.message);
+      });
+  }
+
+  update_settings(settings: ISettingRegistry.ISettings) {
+    this.settings = settings;
+    const tokens = settings.get('ignore').composite as Array<string>;
+    this.ignored_tokens = new Set(tokens);
+    this.accepted_types = settings.get('mimeTypes').composite as Array<string>;
+
+    // read the saved language setting
+    const language_code = settings.get('language').composite;
+    const user_language = languages.filter((l) => l.code === language_code)[0];
+    if (user_language === undefined) {
+      console.warn('The language ' + language_code + ' is not supported!');
+    } else {
+      this.language = user_language;
+      // load the dictionary
+      this.load_dictionary().catch(console.warn);
+    }
+    this.refresh_state();
+  }
+
+  setup_file_editor(file_editor: FileEditor, setup_signal = false): void {
+    if (
+      this.accepted_types &&
+      this.accepted_types.indexOf(file_editor.model.mimeType) !== -1
+    ) {
+      const editor = this.extract_editor(file_editor);
+      this.setup_overlay(editor);
+    }
+    if (setup_signal) {
+      file_editor.model.mimeTypeChanged.connect((model, args) => {
+        // putting at the end of execution queue to allow the CodeMirror mode to be updated
+        setTimeout(() => this.setup_file_editor(file_editor), 0);
+      });
+    }
+  }
+
+  setup_cell_editor(cell: Cell): void {
+    if (cell !== null && cell.model.type === 'markdown') {
+      const editor = this.extract_editor(cell);
+      this.setup_overlay(editor);
+    }
+  }
+
+  extract_editor(cell_or_editor: Cell | FileEditor): CodeMirror.Editor {
+    const editor_temp = cell_or_editor.editor as CodeMirrorEditor;
+    return editor_temp.editor;
+  }
+
+  setup_overlay(editor: CodeMirror.Editor, retry = true): void {
+    const current_mode = editor.getOption('mode') as string;
+
+    if (current_mode === 'null') {
+      if (retry) {
+        // putting at the end of execution queue to allow the CodeMirror mode to be updated
+        setTimeout(() => this.setup_overlay(editor, false), 0);
+      }
+      return;
     }
 
-    // move the load_dictionary into the setup routine, because then
-    // we know that the values are set correctly!
-    setup_settings() {
-        Promise.all([this.setting_registry.load(extension.id), this.app.restored])
-          .then(([settings]) => {
-              this.update_settings(settings);
-              settings.changed.connect(() => {
-                  this.update_settings(settings);
-              });
-          })
-          .catch((reason: Error) => {
-              console.error(reason.message);
-          });
+    if (this.check_spelling) {
+      editor.setOption('mode', this.define_mode(current_mode));
+    } else {
+      const original_mode = current_mode.match(/^spellcheck_/)
+        ? current_mode.substr(11)
+        : current_mode;
+      editor.setOption('mode', original_mode);
     }
+  }
 
-    update_settings(settings: ISettingRegistry.ISettings) {
-        this.settings = settings;
-        let tokens = settings.get('ignore').composite as Array<string>;
-        this.ignored_tokens = new Set(tokens);
-        this.accepted_types = settings.get('mimeTypes').composite as Array<string>;
+  toggle_spellcheck() {
+    this.check_spelling = !this.check_spelling;
+    console.log('Spell checking is currently: ', this.check_spelling);
+  }
 
-        // read the saved language setting
-        let language_code = settings.get('language').composite;
-        let user_language = languages.filter(l => l.code == language_code)[0];
-        if (user_language === undefined)
-        {
-          console.warn('The language ' + language_code + ' is not supported!')
-        }
-        else
-        {
-          this.language = user_language;
-          // load the dictionary
-          this.load_dictionary().catch(console.warn);
-        }
-        this.refresh_state()
+  setup_button() {
+    this.app.commands.addCommand(CommandIDs.toggle, {
+      label: 'Toggle spellchecker',
+      execute: () => {
+        this.toggle_spellcheck();
+      },
+    });
+    if (this.palette) {
+      this.palette.addItem({
+        command: CommandIDs.toggle,
+        category: PALETTE_CATEGORY,
+      });
     }
+  }
 
-    setup_file_editor(file_editor: FileEditor, setup_signal=false): void {
-        if (this.accepted_types && this.accepted_types.indexOf(file_editor.model.mimeType) !== -1) {
-            let editor = this.extract_editor(file_editor);
-            this.setup_overlay(editor);
-        }
-        if (setup_signal) {
-            file_editor.model.mimeTypeChanged.connect((model, args) => {
-                // putting at the end of execution queue to allow the CodeMirror mode to be updated
-                setTimeout(() => this.setup_file_editor(file_editor), 0)
-            })
-        }
+  get_contextmenu_context(): IContext | null {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const event = this.app._contextMenuEvent as MouseEvent;
+    const target = event.target as HTMLElement;
+    const code_mirror_wrapper: any = target.closest('.CodeMirror');
+    if (code_mirror_wrapper === null) {
+      return null;
     }
+    const code_mirror = code_mirror_wrapper.CodeMirror as CodeMirror.Editor;
+    const position = code_mirror.coordsChar({
+      left: event.clientX,
+      top: event.clientY,
+    });
 
-    setup_cell_editor(cell: Cell): void {
-        if ((cell !== null) && (cell.model.type == "markdown")) {
-            let editor = this.extract_editor(cell);
-            this.setup_overlay(editor);
-        }
+    return {
+      editor: code_mirror,
+      position: position,
+    };
+  }
+
+  /**
+   * This is different from token as implemented in CodeMirror
+   * and needed because Markdown does not tokenize words
+   * (each letter outside of markdown features is a separate token!)
+   */
+  get_current_word(context: IContext): IWord {
+    const { editor, position } = context;
+    const line = editor.getDoc().getLine(position.line);
+    let start = position.ch;
+    while (start > 0 && line[start].match(this.rx_word_char)) {
+      start--;
     }
-
-    extract_editor(cell_or_editor: Cell | FileEditor): CodeMirror.Editor {
-        let editor_temp = cell_or_editor.editor;
-        // @ts-ignore
-        return editor_temp._editor;
+    let end = position.ch;
+    while (end < line.length && line[end].match(this.rx_word_char)) {
+      end++;
     }
+    return {
+      line: position.line,
+      start: start,
+      end: end,
+      text: line.substring(start, end),
+    };
+  }
 
-    setup_overlay(editor: CodeMirror.Editor, retry=true): void {
-        let current_mode = editor.getOption("mode") as string;
+  setup_suggestions() {
+    this.suggestions_menu = new Menu({ commands: this.app.commands });
+    this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
+    this.suggestions_menu.title.icon = spellcheckIcon.bindprops({
+      stylesheet: 'menuItem',
+    });
 
-        if (current_mode == "null"){
-            if (retry) {
-                // putting at the end of execution queue to allow the CodeMirror mode to be updated
-                setTimeout(() => this.setup_overlay(editor, false), 0)
+    // this command is not meant to be show - it is just menu trigger detection hack
+    this.app.commands.addCommand(CommandIDs.updateSuggestions, {
+      execute: (args) => {
+        // no-op
+      },
+      isVisible: (args) => {
+        this.prepare_suggestions();
+        return false;
+      },
+    });
+    this.app.contextMenu.addItem({
+      selector: '.cm-spell-error',
+      command: CommandIDs.updateSuggestions,
+    });
+    // end of the menu trigger detection hack
+
+    this.app.contextMenu.addItem({
+      selector: '.cm-spell-error',
+      submenu: this.suggestions_menu,
+      type: 'submenu',
+    });
+    this.app.commands.addCommand(CommandIDs.applySuggestion, {
+      execute: (args) => {
+        this.apply_suggestion(args['name'] as string);
+      },
+      label: (args) => args['name'] as string,
+    });
+  }
+
+  setup_ignore_action() {
+    this.app.commands.addCommand(CommandIDs.ignoreWord, {
+      execute: () => {
+        this.ignore();
+      },
+      label: 'Ignore',
+    });
+
+    this.app.contextMenu.addItem({
+      selector: '.cm-spell-error',
+      command: CommandIDs.ignoreWord,
+    });
+  }
+
+  ignore() {
+    const context = this.get_contextmenu_context();
+
+    if (context === null) {
+      console.log(
+        'Could not ignore the word as the context was no longer available'
+      );
+    } else {
+      const word = this.get_current_word(context);
+      this.settings
+        .set('ignore', [
+          word.text.trim(),
+          ...(this.settings.get('ignore').composite as Array<string>),
+        ])
+        .catch(console.warn);
+    }
+  }
+
+  prepare_suggestions() {
+    const context = this.get_contextmenu_context();
+    let suggestions: string[];
+    if (context === null) {
+      // no context (e.g. the edit was applied and the token is no longer in DOM,
+      // so we cannot find the parent editor
+      suggestions = [];
+    } else {
+      const word = this.get_current_word(context);
+      suggestions = this.dictionary.suggest(word.text);
+    }
+    this.suggestions_menu.clearItems();
+
+    if (suggestions.length) {
+      for (const suggestion of suggestions) {
+        this.suggestions_menu.addItem({
+          command: CommandIDs.applySuggestion,
+          args: { name: suggestion },
+        });
+      }
+      this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
+      this.suggestions_menu.title.className = '';
+      this.suggestions_menu.setHidden(false);
+    } else {
+      this.suggestions_menu.title.className = 'lm-mod-disabled';
+      this.suggestions_menu.title.label = TEXT_NO_SUGGESTIONS;
+      this.suggestions_menu.setHidden(true);
+    }
+  }
+
+  apply_suggestion(replacement: string) {
+    const context = this.get_contextmenu_context();
+    if (context === null) {
+      console.warn(
+        'Applying suggestion failed (probably was already applied earlier)'
+      );
+      return;
+    }
+    const word = this.get_current_word(context);
+
+    context.editor.getDoc().replaceRange(
+      replacement,
+      {
+        ch: word.start,
+        line: word.line,
+      },
+      {
+        ch: word.end,
+        line: word.line,
+      }
+    );
+  }
+
+  load_dictionary() {
+    return Promise.all([
+      fetch(this.language.aff).then((res) => res.text()),
+      fetch(this.language.dic).then((res) => res.text()),
+    ]).then((values) => {
+      this.dictionary = new Typo(this.language.name, values[0], values[1]);
+      console.log('Dictionary Loaded ', this.language.name, this.language.code);
+
+      // update the complete UI
+      this.status_widget.update();
+      this.refresh_state();
+    });
+  }
+
+  define_mode = (original_mode_spec: string) => {
+    if (original_mode_spec.indexOf('spellcheck_') === 0) {
+      return original_mode_spec;
+    }
+    const new_mode_spec = 'spellcheck_' + original_mode_spec;
+    CodeMirror.defineMode(new_mode_spec, (config: any) => {
+      const spellchecker_overlay = {
+        name: new_mode_spec,
+        token: (stream: any, state: any) => {
+          if (stream.eatWhile(this.rx_word_char)) {
+            const word = stream.current().replace(/(^')|('$)/g, '');
+            if (
+              !word.match(/^\d+$/) &&
+              this.dictionary !== undefined &&
+              !this.dictionary.check(word) &&
+              !this.ignored_tokens.has(word)
+            ) {
+              return 'spell-error';
             }
-            return;
-        }
-
-        if (this.check_spelling){
-            editor.setOption("mode", this.define_mode(current_mode));
-        } else{
-            let original_mode = (current_mode.match(/^spellcheck_/)) ? current_mode.substr(11) : current_mode
-            editor.setOption("mode", original_mode);
-        }
-    }
-
-    toggle_spellcheck(){
-        this.check_spelling = ! this.check_spelling;
-        console.log("Spell checking is currently: ", this.check_spelling);
-    }
-
-    setup_button(){
-        this.app.commands.addCommand(CMD_TOGGLE, {
-            label: "Check Spelling",
-            execute: () => {
-                this.toggle_spellcheck();
-            }
-        });
-        this.palette.addItem( {command: CMD_TOGGLE, category: "Toggle Spell Checker"} );
-    }
-
-    get_contextmenu_context(): IContext | null {
-        // @ts-ignore
-        let event = this.app._contextMenuEvent as MouseEvent;
-        let target = event.target as HTMLElement;
-        let code_mirror_wrapper: any = target.closest('.CodeMirror');
-        if (code_mirror_wrapper === null) {
-            return null;
-        }
-        let code_mirror = code_mirror_wrapper.CodeMirror as CodeMirror.Editor;
-        let position = code_mirror.coordsChar({
-            left: event.clientX,
-            top: event.clientY
-        }, );
-
-        return {
-            editor: code_mirror,
-            position: position
-        };
-    }
-
-    /**
-     * This is different from token as implemented in CodeMirror
-     * and needed because Markdown does not tokenize words
-     * (each letter outside of markdown features is a separate token!)
-     */
-    get_current_word(context: IContext): IWord {
-        let { editor, position } = context;
-        let line = editor.getDoc().getLine(position.line);
-        let start = position.ch;
-        while (start > 0 && line[start].match(this.rx_word_char)) {
-            start--;
-        }
-        let end = position.ch;
-        while (end < line.length && line[end].match(this.rx_word_char)) {
-            end++;
-        }
-        return {
-            line: position.line,
-            start: start,
-            end: end,
-            text: line.substring(start, end)
-        }
-    }
-
-    setup_suggestions() {
-        this.suggestions_menu = new Menu({commands: this.app.commands});
-        this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
-        this.suggestions_menu.title.icon = spellcheckIcon.bindprops({ stylesheet: 'menuItem' });
-
-        // this command is not meant to be show - it is just menu trigger detection hack
-        this.app.commands.addCommand(CMD_UPDATE_SUGGESTIONS, {
-            execute: args => {},
-            isVisible: (args) => {
-                this.prepare_suggestions();
-                return false;
-            }
-        });
-        this.app.contextMenu.addItem({
-            selector: '.cm-spell-error',
-            command: CMD_UPDATE_SUGGESTIONS
-        });
-        // end of the menu trigger detection hack
-
-        this.app.contextMenu.addItem({
-            selector: '.cm-spell-error',
-            submenu: this.suggestions_menu,
-            type: 'submenu'
-        });
-        this.app.commands.addCommand(CMD_APPLY_SUGGESTION, {
-            execute: args => {
-                this.apply_suggestion(args['name'] as string);
-            },
-            label: args => args['name'] as string
-        });
-    }
-
-    setup_ignore_action() {
-        this.app.commands.addCommand(CMD_IGNORE_WORD, {
-            execute: () => { this.ignore() },
-            label: 'Ignore'
-        });
-
-        this.app.contextMenu.addItem({
-            selector: '.cm-spell-error',
-            command: CMD_IGNORE_WORD
-        });
-    }
-
-    ignore() {
-        let context = this.get_contextmenu_context();
-
-        if (context === null) {
-          console.log('Could not ignore the word as the context was no longer available')
-        } else {
-            let word = this.get_current_word(context);
-            this.settings.set(
-              'ignore',
-              [word.text.trim(), ...(this.settings.get('ignore').composite as Array<string>)]
-            ).catch(console.warn);
-        }
-    }
-
-    prepare_suggestions() {
-        let context = this.get_contextmenu_context();
-        let suggestions: string[]
-        if (context === null) {
-            // no context (e.g. the edit was applied and the token is no longer in DOM,
-            // so we cannot find the parent editor
-            suggestions = [];
-        } else {
-            let word = this.get_current_word(context);
-            suggestions = this.dictionary.suggest(word.text);
-        }
-        this.suggestions_menu.clearItems();
-
-        if (suggestions.length) {
-            for (let suggestion of suggestions) {
-                this.suggestions_menu.addItem({
-                    command: CMD_APPLY_SUGGESTION,
-                    args: { name: suggestion }
-                });
-            }
-            this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
-            this.suggestions_menu.title.className = ''
-            this.suggestions_menu.setHidden(false)
-        } else {
-            this.suggestions_menu.title.className = 'lm-mod-disabled'
-            this.suggestions_menu.title.label = TEXT_NO_SUGGESTIONS;
-            this.suggestions_menu.setHidden(true)
-        }
-    }
-
-    apply_suggestion(replacement: string) {
-        let context = this.get_contextmenu_context();
-        if (context === null) {
-            console.warn('Applying suggestion failed (probably was already applied earlier)')
-            return;
-        }
-        let word = this.get_current_word(context);
-
-        context.editor.getDoc().replaceRange(
-          replacement,
-          {
-              ch: word.start,
-              line: word.line
-          },
-          {
-              ch: word.end,
-              line: word.line
           }
-        )
+          stream.eatWhile(this.rx_non_word_char);
+          return null;
+        },
+      };
+      return CodeMirror.overlayMode(
+        CodeMirror.getMode(config, original_mode_spec),
+        spellchecker_overlay,
+        true
+      );
+    });
+    return new_mode_spec;
+  };
+
+  refresh_state() {
+    // update the active cell (if any)
+    if (this.tracker.activeCell !== null) {
+      this.setup_cell_editor(this.tracker.activeCell);
     }
 
-    load_dictionary() {
-        return Promise.all([
-            fetch(this.language.aff).then(res => res.text()),
-            fetch(this.language.dic).then(res => res.text())
-        ]).then((values) => {
-            this.dictionary = new Typo(this.language.name, values[0], values[1]);
-            console.log("Dictionary Loaded ", this.language.name, this.language.code);
+    // update the current file editor (if any)
+    if (this.editor_tracker.currentWidget !== null) {
+      this.setup_file_editor(this.editor_tracker.currentWidget.content);
+    }
+  }
 
-            // update the complete UI
-            this.status_widget.update();
-            this.refresh_state()
+  choose_language() {
+    // show the current language first, then all others
+    const choices = [
+      this.language,
+      ...languages.filter((l) => l.name !== this.language.name),
+    ];
+
+    InputDialog.getItem({
+      title: 'Choose spellchecker language',
+      items: choices.map((language) => language.name),
+    }).then((value) => {
+      if (value.value !== null) {
+        this.language = languages.filter((l) => l.name === value.value)[0];
+        this.load_dictionary().then(() => {
+          // save the chosen language in the settings
+          this.settings.set('language', this.language.code).catch(console.warn);
         });
+      }
+    });
+  }
+
+  setup_language_picker() {
+    this.status_widget = new StatusWidget(() => this.language.name);
+    this.status_widget.node.onclick = () => {
+      this.choose_language();
+    };
+    this.app.commands.addCommand(CommandIDs.chooseLanguage, {
+      execute: (args) => this.choose_language(),
+      label: 'Choose spellchecker language',
+    });
+
+    if (this.palette) {
+      this.palette.addItem({
+        command: CommandIDs.chooseLanguage,
+        category: PALETTE_CATEGORY,
+      });
     }
 
-    define_mode = (original_mode_spec: string) => {
-        if (original_mode_spec.indexOf("spellcheck_") == 0){
-            return original_mode_spec;
-        }
-        let me = this;
-        let new_mode_spec = 'spellcheck_' + original_mode_spec;
-        CodeMirror.defineMode(new_mode_spec, (config:any) => {
-            let spellchecker_overlay = {
-                name: new_mode_spec,
-                token: function (stream:any, state:any) {
-                    if (stream.eatWhile(me.rx_word_char)) {
-                        let word = stream.current().replace(/(^')|('$)/g, '');
-                        if (!word.match(/^\d+$/) && (me.dictionary !== undefined) && !me.dictionary.check(word) && !me.ignored_tokens.has(word)) {
-                            return 'spell-error';
-                        }
-                    }
-                    stream.eatWhile(me.rx_non_word_char);
-                    return null;
-                }
-            };
-            return CodeMirror.overlayMode(
-                CodeMirror.getMode(config, original_mode_spec), spellchecker_overlay, true);
-        });
-        return new_mode_spec;
+    if (this.status_bar) {
+      this.status_bar.registerStatusItem('spellchecker:choose-language', {
+        align: 'right',
+        item: this.status_widget,
+      });
     }
-
-    refresh_state() {
-        // update the active cell (if any)
-        if (this.tracker.activeCell != null) {
-            this.setup_cell_editor(this.tracker.activeCell);
-        }
-
-        // update the current file editor (if any)
-        if (this.editor_tracker.currentWidget != null) {
-            this.setup_file_editor(this.editor_tracker.currentWidget.content);
-        }
-    }
-
-    choose_language() {
-        // show the current language first, then all others
-        const choices = [this.language, ...languages.filter(l => l.name != this.language.name)]
-
-        InputDialog.getItem({
-            title: 'Choose spellchecker language',
-            items: choices.map(language => language.name)
-        }).then(value => {
-            if (value.value != null) {
-                this.language = languages.filter(l => l.name == value.value)[0];
-                this.load_dictionary().then(() => {
-                    // save the choosen language in the settings
-                    this.settings.set(
-                      'language',
-                      this.language.code
-                    );
-                });
-            }
-        });
-    }
-
-    setup_language_picker() {
-        this.status_widget = new StatusWidget(() => this.language.name);
-        this.status_widget.node.onclick = () => {
-            this.choose_language();
-        }
-        this.status_bar.registerStatusItem(
-          'spellchecker:choose-language',
-          {
-              align: 'right',
-              item: this.status_widget
-          }
-        )
-    }
+  }
 }
-
 
 /**
  * Activate extension
  */
-function activate(app: JupyterFrontEnd, tracker: INotebookTracker, palette: ICommandPalette, editor_tracker: IEditorTracker, status_bar: IStatusBar, setting_registry: ISettingRegistry) {
-    console.log('Attempting to load spellchecker');
-    const sp = new SpellChecker(app, tracker, palette, editor_tracker, status_bar, setting_registry);
-    console.log("Spellchecker Loaded ", sp);
+function activate(
+  app: JupyterFrontEnd,
+  tracker: INotebookTracker,
+  palette: ICommandPalette,
+  editor_tracker: IEditorTracker,
+  setting_registry: ISettingRegistry,
+  status_bar: IStatusBar
+): void {
+  console.log('Attempting to load spellchecker');
+  const sp = new SpellChecker(
+    app,
+    tracker,
+    editor_tracker,
+    setting_registry,
+    palette,
+    status_bar
+  );
+  console.log('Spellchecker Loaded ', sp);
 }
-
 
 /**
  * Initialization data for the jupyterlab_spellchecker extension.
  */
 const extension: JupyterFrontEndPlugin<void> = {
-    id: '@ijmbarr/jupyterlab_spellchecker:plugin',
-    autoStart: true,
-    requires: [INotebookTracker, ICommandPalette, IEditorTracker, IStatusBar, ISettingRegistry],
-    activate: activate
+  id: '@ijmbarr/jupyterlab_spellchecker:plugin',
+  autoStart: true,
+  requires: [INotebookTracker, IEditorTracker, ISettingRegistry],
+  optional: [ICommandPalette, IStatusBar],
+  activate: activate,
 };
 
 export default extension;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin,
+  JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
 import { INotebookTracker } from '@jupyterlab/notebook';
@@ -8,7 +8,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import {
   ICommandPalette,
   InputDialog,
-  ReactWidget,
+  ReactWidget
 } from '@jupyterlab/apputils';
 import { Menu } from '@lumino/widgets';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -23,7 +23,7 @@ import spellcheckSvg from '../style/icons/ic-baseline-spellcheck.svg';
 
 export const spellcheckIcon = new LabIcon({
   name: 'spellcheck:spellcheck',
-  svgstr: spellcheckSvg,
+  svgstr: spellcheckSvg
 });
 
 declare function require(name: string): any;
@@ -35,7 +35,7 @@ const enum CommandIDs {
   ignoreWord = 'spellchecker:ignore',
   toggle = 'spellchecker:toggle-check-spelling',
   updateSuggestions = 'spellchecker:update-suggestions',
-  chooseLanguage = 'spellchecker:choose-language',
+  chooseLanguage = 'spellchecker:choose-language'
 }
 
 const TEXT_SUGGESTIONS_AVAILABLE = 'Adjust spelling to';
@@ -104,19 +104,19 @@ const languages: ILanguage[] = [
     code: 'en-au',
     name: 'English (Australian)',
     aff: en_au_aff,
-    dic: en_au_dic,
+    dic: en_au_dic
   },
   {
     code: 'de-de',
     name: 'Deutsch (Deutschland)',
     aff: de_de_aff,
-    dic: de_de_dic,
+    dic: de_de_dic
   },
   {
     code: 'de-at',
     name: 'Deutsch (Österreich)',
     aff: de_at_aff,
-    dic: de_at_dic,
+    dic: de_at_dic
   },
   { code: 'de-ch', name: 'Deutsch (Schweiz)', aff: de_ch_aff, dic: de_ch_dic },
   { code: 'fr-fr', name: 'Français (France)', aff: fr_fr_aff, dic: fr_fr_dic },
@@ -126,8 +126,8 @@ const languages: ILanguage[] = [
     code: 'pt-pt',
     name: 'Português (Portugal)',
     aff: pt_pt_aff,
-    dic: pt_pt_dic,
-  },
+    dic: pt_pt_dic
+  }
 ];
 
 class StatusWidget extends ReactWidget {
@@ -180,17 +180,21 @@ class SpellChecker {
     this.setup_language_picker();
     this.setup_ignore_action();
 
-    this.tracker.activeCellChanged.connect(() =>
-      this.setup_cell_editor(this.tracker.activeCell)
-    );
+    this.tracker.activeCellChanged.connect(() => {
+      if (this.tracker.activeCell) {
+        this.setup_cell_editor(this.tracker.activeCell);
+      }
+    });
     // setup newly open editors
     this.editor_tracker.widgetAdded.connect((sender, widget) =>
       this.setup_file_editor(widget.content, true)
     );
     // refresh already open editors when activated (because the MIME type might have changed)
-    this.editor_tracker.currentChanged.connect((sender, widget) =>
-      this.setup_file_editor(widget.content, false)
-    );
+    this.editor_tracker.currentChanged.connect((sender, widget) => {
+      if (widget !== null) {
+        this.setup_file_editor(widget.content, false);
+      }
+    });
   }
 
   // move the load_dictionary into the setup routine, because then
@@ -216,7 +220,7 @@ class SpellChecker {
 
     // read the saved language setting
     const language_code = settings.get('language').composite;
-    const user_language = languages.filter((l) => l.code === language_code)[0];
+    const user_language = languages.filter(l => l.code === language_code)[0];
     if (user_language === undefined) {
       console.warn('The language ' + language_code + ' is not supported!');
     } else {
@@ -286,12 +290,12 @@ class SpellChecker {
       label: 'Toggle spellchecker',
       execute: () => {
         this.toggle_spellcheck();
-      },
+      }
     });
     if (this.palette) {
       this.palette.addItem({
         command: CommandIDs.toggle,
-        category: PALETTE_CATEGORY,
+        category: PALETTE_CATEGORY
       });
     }
   }
@@ -308,12 +312,12 @@ class SpellChecker {
     const code_mirror = code_mirror_wrapper.CodeMirror as CodeMirror.Editor;
     const position = code_mirror.coordsChar({
       left: event.clientX,
-      top: event.clientY,
+      top: event.clientY
     });
 
     return {
       editor: code_mirror,
-      position: position,
+      position: position
     };
   }
 
@@ -337,7 +341,7 @@ class SpellChecker {
       line: position.line,
       start: start,
       end: end,
-      text: line.substring(start, end),
+      text: line.substring(start, end)
     };
   }
 
@@ -345,35 +349,35 @@ class SpellChecker {
     this.suggestions_menu = new Menu({ commands: this.app.commands });
     this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
     this.suggestions_menu.title.icon = spellcheckIcon.bindprops({
-      stylesheet: 'menuItem',
+      stylesheet: 'menuItem'
     });
 
     // this command is not meant to be show - it is just menu trigger detection hack
     this.app.commands.addCommand(CommandIDs.updateSuggestions, {
-      execute: (args) => {
+      execute: args => {
         // no-op
       },
-      isVisible: (args) => {
+      isVisible: args => {
         this.prepare_suggestions();
         return false;
-      },
+      }
     });
     this.app.contextMenu.addItem({
       selector: '.cm-spell-error',
-      command: CommandIDs.updateSuggestions,
+      command: CommandIDs.updateSuggestions
     });
     // end of the menu trigger detection hack
 
     this.app.contextMenu.addItem({
       selector: '.cm-spell-error',
       submenu: this.suggestions_menu,
-      type: 'submenu',
+      type: 'submenu'
     });
     this.app.commands.addCommand(CommandIDs.applySuggestion, {
-      execute: (args) => {
+      execute: args => {
         this.apply_suggestion(args['name'] as string);
       },
-      label: (args) => args['name'] as string,
+      label: args => args['name'] as string
     });
   }
 
@@ -382,12 +386,12 @@ class SpellChecker {
       execute: () => {
         this.ignore();
       },
-      label: 'Ignore',
+      label: 'Ignore'
     });
 
     this.app.contextMenu.addItem({
       selector: '.cm-spell-error',
-      command: CommandIDs.ignoreWord,
+      command: CommandIDs.ignoreWord
     });
   }
 
@@ -403,7 +407,7 @@ class SpellChecker {
       this.settings
         .set('ignore', [
           word.text.trim(),
-          ...(this.settings.get('ignore').composite as Array<string>),
+          ...(this.settings.get('ignore').composite as Array<string>)
         ])
         .catch(console.warn);
     }
@@ -426,7 +430,7 @@ class SpellChecker {
       for (const suggestion of suggestions) {
         this.suggestions_menu.addItem({
           command: CommandIDs.applySuggestion,
-          args: { name: suggestion },
+          args: { name: suggestion }
         });
       }
       this.suggestions_menu.title.label = TEXT_SUGGESTIONS_AVAILABLE;
@@ -453,20 +457,20 @@ class SpellChecker {
       replacement,
       {
         ch: word.start,
-        line: word.line,
+        line: word.line
       },
       {
         ch: word.end,
-        line: word.line,
+        line: word.line
       }
     );
   }
 
   load_dictionary() {
     return Promise.all([
-      fetch(this.language.aff).then((res) => res.text()),
-      fetch(this.language.dic).then((res) => res.text()),
-    ]).then((values) => {
+      fetch(this.language.aff).then(res => res.text()),
+      fetch(this.language.dic).then(res => res.text())
+    ]).then(values => {
       this.dictionary = new Typo(this.language.name, values[0], values[1]);
       console.log('Dictionary Loaded ', this.language.name, this.language.code);
 
@@ -498,7 +502,7 @@ class SpellChecker {
           }
           stream.eatWhile(this.rx_non_word_char);
           return null;
-        },
+        }
       };
       return CodeMirror.overlayMode(
         CodeMirror.getMode(config, original_mode_spec),
@@ -525,15 +529,15 @@ class SpellChecker {
     // show the current language first, then all others
     const choices = [
       this.language,
-      ...languages.filter((l) => l.name !== this.language.name),
+      ...languages.filter(l => l.name !== this.language.name)
     ];
 
     InputDialog.getItem({
       title: 'Choose spellchecker language',
-      items: choices.map((language) => language.name),
-    }).then((value) => {
+      items: choices.map(language => language.name)
+    }).then(value => {
       if (value.value !== null) {
-        this.language = languages.filter((l) => l.name === value.value)[0];
+        this.language = languages.filter(l => l.name === value.value)[0];
         this.load_dictionary().then(() => {
           // save the chosen language in the settings
           this.settings.set('language', this.language.code).catch(console.warn);
@@ -548,21 +552,21 @@ class SpellChecker {
       this.choose_language();
     };
     this.app.commands.addCommand(CommandIDs.chooseLanguage, {
-      execute: (args) => this.choose_language(),
-      label: 'Choose spellchecker language',
+      execute: args => this.choose_language(),
+      label: 'Choose spellchecker language'
     });
 
     if (this.palette) {
       this.palette.addItem({
         command: CommandIDs.chooseLanguage,
-        category: PALETTE_CATEGORY,
+        category: PALETTE_CATEGORY
       });
     }
 
     if (this.status_bar) {
       this.status_bar.registerStatusItem('spellchecker:choose-language', {
         align: 'right',
-        item: this.status_widget,
+        item: this.status_widget
       });
     }
   }
@@ -599,7 +603,7 @@ const extension: JupyterFrontEndPlugin<void> = {
   autoStart: true,
   requires: [INotebookTracker, IEditorTracker, ISettingRegistry],
   optional: [ICommandPalette, IStatusBar],
-  activate: activate,
+  activate: activate
 };
 
 export default extension;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "strict": true,
     "strictPropertyInitialization": false,
     "target": "ES6",
-    "outDir": "./lib",
+    "outDir": "lib",
+    "rootDir": "src",
     "lib": ["ES5", "ES6", "ES2015.Promise", "DOM"],
     "types": []
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
     "declaration": true,
     "esModuleInterop": true,
+    "incremental": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "strict": true,
+    "strictPropertyInitialization": false,
     "target": "ES6",
     "outDir": "./lib",
     "lib": ["ES5", "ES6", "ES2015.Promise", "DOM"],


### PR DESCRIPTION
- [x] fixes eslint errors and warnings on CI
- [x] aligns with the current jupyterlab extension cookiecutter:
    - [x] adds CI and binder badge from cookiecutter
    - [x] updates eslint rules
    - [x] adds federated extension
- [x] makes statusbar and palette optional to make it possible to use with other frontends such as jupyterlab-classic
- [x] updates references to organization and repo to point to jupyterlab-contrib
- [x] updates outdated README
- [x] adds "Choose language" command to the command palette
- [ ] maybe rename to @jupyterlab-contrib/spellchecker? (will be done in the next PR to update extension under current namespace with links to this repository)